### PR TITLE
Correctly tokenize URL paths with forward slashes

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -106,8 +106,6 @@ module.exports = function(value) {
 					return;
 				}
 			}
-		} else {
-      console.warn('Did not recognize token', v);
 		}
 	}
 

--- a/source/background.js
+++ b/source/background.js
@@ -25,7 +25,7 @@ var normalizeUrl = function(value) {
 module.exports = function(value) {
 	var result = {};
 	var values = normalizeUrl(normalizeColor(value))
-		.replace(/\//, ' / ')
+    .replace(/\(.*\/.*\)|(\/)+/g, (match, group1) => (!group1) ? match : ' / ')
 		.split(/\s+/);
 
 	var first = values[0];
@@ -107,7 +107,7 @@ module.exports = function(value) {
 				}
 			}
 		} else {
-			return;
+      console.warn('Did not recognize token', v);
 		}
 	}
 

--- a/test/fixtures/background.json
+++ b/test/fixtures/background.json
@@ -1,4 +1,10 @@
 {
+	"url(/testSite/wp-content/themes/BareBones/images/bg3.png) no-repeat center center fixed": {
+    "background-image": "url(/testSite/wp-content/themes/BareBones/images/bg3.png)",
+    "background-position": "center center",
+    "background-repeat": "no-repeat",
+    "background-attachment": "fixed"
+  },
 	"scroll": {
 		"background-attachment": "scroll"
 	},


### PR DESCRIPTION
Currently, the `background` module splits the value into tokens with the `/` character as the delimiter. This means that the following value

```
'url(/testSite/wp-content/themes/BareBones/images/bg3.png) no-repeat center center fixed'
```

gets split into the following array of tokens:

```
[ 'url(',
  '/',
  'testSite/wp-content/themes/BareBones/images/bg3.png)',
  'no-repeat',
  'center',
  'center',
  'fixed' ]
```

Moreover, the `background` parsing module doesn't provide any warning when it encounters an unrecognized token; instead, it silently returns `undefined` and doesn't attempt to continue parsing the remaining tokens.

I updated the tokenizer regex to ignore forward slashes contained within parens (to permit URLs with forward slashes), added a `console.warn`ing to handle unrecognized tokens, and removed the early return. All original tests still pass.
