### PR TITLE
you can't parse css values with a regex.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "css-color-names": "0.0.1",
     "css-url-regex": "0.0.1",
+    "gonzales": "^1.0.7",
     "hex-color-regex": "^1.0.1",
     "hsl-regex": "^1.0.0",
     "hsla-regex": "^1.0.0",

--- a/source/background.js
+++ b/source/background.js
@@ -3,6 +3,8 @@ var map = require('map-obj');
 var isColor = require('./is-color');
 var isLength = require('./is-length');
 var normalizeColor = require('./normalize-color');
+var splitValueOnSpace = require("./split-value-on-space");
+
 
 var ATTACHMENT = /^(fixed|local|scroll)$/;
 var BOX = /^(border-box|padding-box|content-box)$/;
@@ -24,9 +26,8 @@ var normalizeUrl = function(value) {
 
 module.exports = function(value) {
 	var result = {};
-	var values = normalizeUrl(normalizeColor(value))
-		.replace(/\//, ' / ')
-		.split(/\s+/);
+	var values = splitValueOnSpace(normalizeUrl(normalizeColor(value))
+		.replace(/\//, ' / '));
 
 	var first = values[0];
 

--- a/source/border.js
+++ b/source/border.js
@@ -4,6 +4,7 @@ var directional = require('./directional');
 var isColor = require('./is-color');
 var isLength = require('./is-length');
 var normalize = require('./normalize-color');
+var splitValueOnSpace = require("./split-value-on-space");
 
 var WIDTH = /^(thin|medium|thick)$/;
 var STYLE = /^(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)$/i;
@@ -30,7 +31,7 @@ var direction = function(direction) {
 };
 
 var all = function(value) {
-	var values = normalize(value).split(/\s+/);
+	var values = splitValueOnSpace(normalize(value));
 	var first = values[0];
 
 	if(values.length > 3) return;

--- a/source/directional.js
+++ b/source/directional.js
@@ -1,8 +1,8 @@
 var repeat = require('repeat-element');
+var splitValueOnSpace = require("./split-value-on-space");
 
 module.exports = function(value) {
-	var values = value.split(/\s+/);
-
+  var values = splitValueOnSpace(value);
 	if(values.length === 1) values = repeat(values[0], 4);
 	else if(values.length === 2) values = values.concat(values);
 	else if(values.length === 3) values.push(values[1]);

--- a/source/outline.js
+++ b/source/outline.js
@@ -3,13 +3,14 @@ var extend = require('xtend');
 var isColor = require('./is-color');
 var isLength = require('./is-length');
 var normalize = require('./normalize-color');
+var splitValueOnSpace = require("./split-value-on-space");
 
 var WIDTH = /^(thin|medium|thick)$/;
 var STYLE = /^(none|hidden|dotted|dashed|solid|double|groove|ridge|inset|outset)$/i;
 var KEYWORD = /^(inherit|initial)$/i;
 
 var outline = function(value) {
-	var values = normalize(value).split(/\s+/);
+  var values = splitValueOnSpace(normalize(value));
 
 	if(values.length > 3) return;
 	if (values.length === 1 && KEYWORD.test(values[0])) {

--- a/source/split-value-on-space.js
+++ b/source/split-value-on-space.js
@@ -1,0 +1,19 @@
+var gonzales = require("gonzales");
+module.exports = function splitValueOnSpace(value) {
+  var valueAST = gonzales.srcToCSSP(value, "value");
+  var values = [];
+  var currentValue = ["value"];
+  for (var i = 1; i < valueAST.length; i++) {
+    v = valueAST[i];
+    if (v[0] === 's') {
+      values.push(gonzales.csspToSrc(currentValue));
+      currentValue = ["value"]
+    } else {
+      currentValue.push(v);
+    }
+  }
+  if (currentValue.length > 0) {
+    values.push(gonzales.csspToSrc(currentValue));
+  }
+  return values;
+}


### PR DESCRIPTION
This fixes some pretty serious bugs with parsing values where complex values like `calc()` are used. It looks like this repo is unmaintained, but I thought I'd try sending this patch anyway.